### PR TITLE
Fix logging string formatting in Win11Debloat

### DIFF
--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -30,7 +30,7 @@ if ($RemoveApps) {
         try {
             Get-AppxPackage -AllUsers -Name $appName | Remove-AppxPackage -AllUsers -ErrorAction SilentlyContinue
         } catch {
-            Write-Log "[!] Failed to remove $appName: $($_.Exception.Message)"
+            Write-Log "[!] Failed to remove ${appName}: $($_.Exception.Message)"
         }
     }
 }
@@ -51,5 +51,5 @@ Write-Log "[✓] Script completed."
 
 if (-not $Silent) {
     Write-Host "Press any key to exit..."
-    $null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+    $null = $Host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown')
 }


### PR DESCRIPTION
## Summary
- fix malformed error logging and console prompts in Win11Debloat.ps1

## Testing
- `pwsh -NoLogo -NoProfile -Command "Get-Command"` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689489ac8fc4832d9cd6e9825de5ebaa